### PR TITLE
Added the ability to save removed elements (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,24 @@ ekill
 
 It's like [**xkill**](https://en.wikipedia.org/wiki/Xkill), but for annoying web pages instead.
 
-Chrome plugin for quickly getting rid of elements on a web page.
+Chrome and Firefox plugin for quickly getting rid of elements on a web page.
 
-Link to the plugin on the [chrome
-web-store](https://chrome.google.com/webstore/detail/ekill/lcgdpfaiipaelnpepigdafiogebaeedg?hl=en).
+## Installation
+
+- [Chrome web store](https://chrome.google.com/webstore/detail/ekill/lcgdpfaiipaelnpepigdafiogebaeedg?hl=en)
+- [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/ekill/)
 
 ![Example](https://raw.githubusercontent.com/rhardih/ekill/master/example.gif)
 
+## options
+- You can make ekill remember your removed elemts by right clicking on the icon and going to 'options'
+- Here you can also reset the pages default settings
 
-**TIP**: Hotkey - Go to [chrome://extensions/shortcuts](chrome://extensions/shortcuts), find the item labeled "ekill" and set ctrl+k, or whatever else is convenient and enjoy even faster killing!
+## Keyboard shortcut
+
+By default **ekill** is toggled with *ctrl+k*, but this can be modified at will.
+
+Go to [chrome://extensions/shortcuts](chrome://extensions/shortcuts), find the item labeled "ekill" and set it to whatever is most convenient.
 
 # License
 
@@ -19,11 +28,15 @@ MIT: http://rhardih.mit-license.org
 
 # Changelog
 
-**1.4**
+**1.5**
 
 - Added an options page 
 - made it possible to store elements a user has removed
 - added permission to access chrome.storage
+
+**1.4**
+
+- Adds support for Firefox
 
 **1.1 - 1.3**
 

--- a/README.md
+++ b/README.md
@@ -3,20 +3,15 @@ ekill
 
 It's like [**xkill**](https://en.wikipedia.org/wiki/Xkill), but for annoying web pages instead.
 
-Chrome and Firefox plugin for quickly getting rid of elements on a web page.
+Chrome plugin for quickly getting rid of elements on a web page.
 
-## Installation
-
-- [Chrome web store](https://chrome.google.com/webstore/detail/ekill/lcgdpfaiipaelnpepigdafiogebaeedg?hl=en)
-- [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/ekill/)
+Link to the plugin on the [chrome
+web-store](https://chrome.google.com/webstore/detail/ekill/lcgdpfaiipaelnpepigdafiogebaeedg?hl=en).
 
 ![Example](https://raw.githubusercontent.com/rhardih/ekill/master/example.gif)
 
-## Keyboard shortcut
 
-By default **ekill** is toggled with *ctrl+k*, but this can be modified at will.
-
-Go to [chrome://extensions/shortcuts](chrome://extensions/shortcuts), find the item labeled "ekill" and set it to whatever is most convenient.
+**TIP**: Hotkey - Go to [chrome://extensions/shortcuts](chrome://extensions/shortcuts), find the item labeled "ekill" and set ctrl+k, or whatever else is convenient and enjoy even faster killing!
 
 # License
 
@@ -26,7 +21,9 @@ MIT: http://rhardih.mit-license.org
 
 **1.4**
 
-- Adds support for Firefox
+- Added an options page 
+- made it possible to store elements a user has removed
+- added permission to access chrome.storage
 
 **1.1 - 1.3**
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ MIT: http://rhardih.mit-license.org
 
 # Changelog
 
+**1.6**
+
+- fixed a few issues with the options page not displaying urls nicely
+- made the code smaller
+- fixed issue with ekill breaking pages like youtube or facebook
+- moved from replacing the whole HTML document to the built in remove()
+
 **1.5**
 
 - Added an options page 

--- a/ekill.js
+++ b/ekill.js
@@ -41,33 +41,20 @@
     
    
     for (let i = 0; i < ekillStorage.length; i++) {
-      /* TODO:
-            1. this loop can be made better (efficiency) by replacing the modified page AFTER the whole loop has run..
-            2. change the matching ('include(etc etc)') to be more loose.. currently it checks the exact string that was removed.. this allows pages to defeat this with randomisation.
-            3. there's probably a better way to do this!!. not sure about looping over html elements. this is by far the easiest i can think of
-      */
-      let _document = d.body;
-      let old_body_class = _document.className; // since we re-construct the body we should add these back.
-      let old_body_id = _document.id;
-      let old_body_style = document.style;
-      //console.log(old_body_class)
-      let documentString = _document.outerHTML.toString();
-      console.log(ekillStorage[i]);
-      if (documentString.includes(ekillStorage[i])) {
 
-        let newHTMLstring = documentString.replace(ekillStorage[i], '');
-        //console.log(ekillStorage[i]);
-        let element = document.createElement("body");
-        element.innerHTML = `${newHTMLstring}`;
-        element.className = old_body_class;
-        element.id = old_body_style;
-        element.style = old_body_style;
-        var oldChild = d.documentElement.replaceChild(element, d.body);
+      
+      let elementDump = document.getElementsByTagName(ekillStorage[i].element);
+      console.log(elementDump);
+      for(let elem = 0; elem < elementDump.length; elem++){ // elem here is an html element
+        console.log(elementDump[elem])
+        if(elementDump[elem].outerHTML === ekillStorage[i].outerHTML){
+          elementDump[elem].remove();
 
-      } else {
-        //console.log('element to remove was not found on the page')
+        }
       }
 
+
+     
 
     }
 
@@ -100,7 +87,7 @@ let saveRemovedElement = function (e) {
     chrome.storage.local.get({[`ekill-replace-${document.URL}`]: []}, function(result) { // try and get data for this URL.. if nothing is there we get [] (empty array)
       //console.log(result);
       let temp = result[`ekill-replace-${document.URL}`]
-      temp.push(e.target.outerHTML.toString());
+      temp.push( {"element": e.target.localName, "outerHTML": e.target.outerHTML.toString()} );
       chrome.storage.local.set(
         {
           [`ekill-replace-${document.URL}`]: temp
@@ -117,6 +104,8 @@ let saveRemovedElement = function (e) {
   let clickHandler = function (e) { // what we need
     disable();
     saveRemovedElement(e); // save the just removed element (will only save if user has the setting 'keepRemoved' to 'true')
+    console.log(e.target.localName);
+    
     e.target.remove();
     e.preventDefault();
     e.stopPropagation();

--- a/ekill.js
+++ b/ekill.js
@@ -52,7 +52,8 @@
       let old_body_style = document.style;
       //console.log(old_body_class)
       let documentString = _document.outerHTML.toString();
-      if (documentString.includes(`${ekillStorage[i]}`)) {
+      console.log(ekillStorage[i]);
+      if (documentString.includes(ekillStorage[i])) {
 
         let newHTMLstring = documentString.replace(ekillStorage[i], '');
         //console.log(ekillStorage[i]);

--- a/ekill.js
+++ b/ekill.js
@@ -9,14 +9,6 @@
 
   });
 
-  if (!localStorage.getItem('ekill-replace')) {
-    localStorage.setItem('ekill-replace', JSON.stringify({
-      "elements": []
-    }));
-  }
-
-
-
 
 
 

--- a/ekill.js
+++ b/ekill.js
@@ -1,4 +1,78 @@
-(function(c, d){
+(function (c, d) {
+
+  let getStoredSettings = new Promise(function (resolve, reject) { // making this a promise due to the async nature of extension storage
+    chrome.storage.sync.get({
+      keepRemoved: false
+    }, function (items) {
+      resolve(items);
+    });
+
+  });
+
+  if (!localStorage.getItem('ekill-replace')) {
+    localStorage.setItem('ekill-replace', JSON.stringify({
+      "elements": []
+    }));
+  }
+
+
+
+
+
+
+
+
+  let docload = function (e) { // document loaded
+    getStoredSettings.then(function (settings) {
+      //console.log(settings);
+      if (settings.keepRemoved === 'true') { // user wants to remove previously removed elements
+        chrome.storage.local.get({[`ekill-replace-${document.URL}`]: []}, function(result) { // try and get data for this URL.. if nothing is there we get [] (empty array)
+          removeSaved(result[`ekill-replace-${document.URL}`]);
+          //console.log(result)
+        });
+      }
+    })
+  };
+
+
+  let removeSaved = function (elementArray) { // removed saved elements 
+    console.warn('removing previously removed HTML elements')
+    let ekillStorage = elementArray;
+    
+   
+    for (let i = 0; i < ekillStorage.length; i++) {
+      /* TODO:
+            1. this loop can be made better (efficiency) by replacing the modified page AFTER the whole loop has run..
+            2. change the matching ('include(etc etc)') to be more loose.. currently it checks the exact string that was removed.. this allows pages to defeat this with randomisation.
+            3. there's probably a better way to do this!!. not sure about looping over html elements. this is by far the easiest i can think of
+      */
+      let _document = d.body;
+      let old_body_class = _document.className; // since we re-construct the body we should add these back.
+      let old_body_id = _document.id;
+      let old_body_style = document.style;
+      //console.log(old_body_class)
+      let documentString = _document.outerHTML.toString();
+      if (documentString.includes(`${ekillStorage[i]}`)) {
+
+        let newHTMLstring = documentString.replace(ekillStorage[i], '');
+        //console.log(ekillStorage[i]);
+        let element = document.createElement("body");
+        element.innerHTML = `${newHTMLstring}`;
+        element.className = old_body_class;
+        element.id = old_body_style;
+        element.style = old_body_style;
+        var oldChild = d.documentElement.replaceChild(element, d.body);
+
+      } else {
+        //console.log('element to remove was not found on the page')
+      }
+
+
+    }
+
+  }
+
+
   let active = false;
   let clickable = [
     d.getElementsByTagName("a"),
@@ -6,32 +80,59 @@
     d.querySelectorAll('[role=button]'),
   ];
 
-  let overHandler = function(e) {
+  let overHandler = function (e) {
     e.target.classList.add("ekill");
     e.stopPropagation();
   };
-  let outHandler = function(e) {
+  let outHandler = function (e) {
     e.target.classList.remove("ekill");
     e.stopPropagation();
   };
-  let clickHandler = function(e) {
+
+
+
+
+let saveRemovedElement = function (e) {
+  getStoredSettings.then(function (settings) { // getting the storage on each click so the user does not have to reload page after they change ekill's settings.
+  if (settings.keepRemoved === 'true') { // we only save elements to remove if this is true
+    // note .. the url is very specific .. not sure if this should be like this or apply to the whole website e.g facebook.com/*
+    chrome.storage.local.get({[`ekill-replace-${document.URL}`]: []}, function(result) { // try and get data for this URL.. if nothing is there we get [] (empty array)
+      //console.log(result);
+      let temp = result[`ekill-replace-${document.URL}`]
+      temp.push(e.target.outerHTML.toString());
+      chrome.storage.local.set(
+        {
+          [`ekill-replace-${document.URL}`]: temp
+        }, function () {
+          console.info('finished saving element')
+        });
+
+    });
+  }
+})
+}
+
+
+  let clickHandler = function (e) { // what we need
     disable();
+    saveRemovedElement(e); // save the just removed element (will only save if user has the setting 'keepRemoved' to 'true')
     e.target.remove();
     e.preventDefault();
     e.stopPropagation();
   };
 
-  let keyHandler = function(e) {
+
+  let keyHandler = function (e) {
     if (e.key === "Escape") {
       disable();
     }
   }
 
-  let enable = function() {
+  let enable = function () {
     active = true;
 
     // override click handlers on any clickable element
-    clickable.forEach(function(c) {
+    clickable.forEach(function (c) {
       for (var i = 0; i < c.length; i++) {
         c[i].onclickBackup = c[i].onclick;
         c[i].addEventListener("click", clickHandler);
@@ -44,10 +145,10 @@
     d.addEventListener("click", clickHandler);
     d.addEventListener("keydown", keyHandler, true);
   };
-  let disable = function() {
+  let disable = function () {
     active = false;
 
-    clickable.forEach(function(c) {
+    clickable.forEach(function (c) {
       for (var i = 0; i < c.length; i++) {
         c[i].removeEventListener("click", clickHandler);
         c[i].addEventListener("click", c[i].onclickBackup);
@@ -70,7 +171,7 @@
   };
 
 
-  let msgHandler = function(message, callback) {
+  let msgHandler = function (message, callback) {
     if (active) {
       disable();
     } else {
@@ -79,6 +180,7 @@
   };
 
   c.runtime.onMessage.addListener(msgHandler);
+  window.addEventListener("load", docload);
 })(chrome, document);
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ekill",
-  "version": "1.4",
+  "version": "1.5",
   "description": "Remove unwanted elements from a page quickly!",
   "manifest_version": 2,
   "browser_action": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,14 +4,15 @@
   "description": "Remove unwanted elements from a page quickly!",
   "manifest_version": 2,
   "browser_action": {
-    "default_icon": {
-      "16": "skull-and-bones-16.png",
-      "48": "skull-and-bones-48.png",
-      "128": "skull-and-bones-128.png"
-    }
+
+  },
+  "options_ui": {
+    "page": "settings.html",
+    "open_in_tab": false
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
   "background": {
     "scripts": ["background.js"],
@@ -28,13 +29,5 @@
     "16": "skull-and-bones-16.png",
     "48": "skull-and-bones-48.png",
     "128": "skull-and-bones-128.png"
-  },
-  "commands": {
-    "_execute_browser_action": {
-      "suggested_key": {
-        "default": "Ctrl+K",
-        "mac": "MacCtrl+K"
-      }
-    }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ekill",
-  "version": "1.5",
+  "version": "1.6",
   "description": "Remove unwanted elements from a page quickly!",
   "manifest_version": 2,
   "browser_action": {

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <title>ekill</title>
+    </head>
+    <body>
+        <h2>Settings</h2>
+        <hr />
+        <br />  
+        <label for="keepRemoved">Save removed elements</label>
+        <select id='keepRemoved'>
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+        </select>
+        <button id='save'>Save</button>
+        <br />
+        
+        <h2>Advanced clearing</h2>
+        <h5>Removed the wrong elements? or just want to reset the functionality? </h5>
+        <div id='URLBOX'> </div>
+
+        
+       
+
+        <script src="settings.js"></script>
+    </body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -34,7 +34,8 @@ function printAllPages(){ // get all the pages we have settings for from storage
             //console.log(result[page])
             if(result[page].length !== 0){
                 let newItem = document.createElement('div');
-                newItem.innerHTML = `<span id='dynamic-${page}' style='padding: 5px;background-color:grey;'>${page.replace('ekill-replace-', '')} --- <button id="${page}">Remove</button></span>`;
+                newItem.innerHTML = `<p id='dynamic-${page}' style='padding: 5px;background-color:grey;color:whitesmoke'>${page.replace('ekill-replace-', '')} --- <button style='float:right;' id="${page}">Remove</button></p>
+                `;
                 URLBOX.appendChild(newItem);
                 document.getElementById(page).addEventListener('click', removeSinglePage); // after we add the item we do this
             }

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,62 @@
+function save_options() { // la laa lalala la lalalala lala
+    let keepRemoved_Value = document.getElementById('keepRemoved').value;
+    //console.log(keepRemoved_Value);
+    chrome.storage.sync.set({ keepRemoved: keepRemoved_Value }, function () {
+
+    });
+}
+
+function previous_settings() {
+    // keepremoved false by default? ..
+    chrome.storage.sync.get({
+        keepRemoved: false
+    }, function (items) {
+        document.getElementById('keepRemoved').value = items.keepRemoved;
+    });
+}
+
+
+function removeSinglePage(e){
+    console.warn(`removing ${e.target.id}`)
+    chrome.storage.local.set({[`${e.target.id}`]: []}, function() {
+       
+      });
+
+    }
+
+function printAllPages(){ // get all the pages we have settings for from storage and updates the DOM
+    chrome.storage.local.get(null, function(result) {
+        //console.log(result);
+        let URLBOX = document.getElementById('URLBOX');
+        for(page in result){  
+          
+            //console.log(result[page])
+            if(result[page].length !== 0){
+                let newItem = document.createElement('div');
+                newItem.innerHTML = `<span style='padding: 5px;background-color:grey;'>${page.replace('ekill-replace-', '')} --- <button id="${page}">Remove</button></span>`;
+                URLBOX.appendChild(newItem);
+                document.getElementById(page).addEventListener('click', removeSinglePage); // after we add the item we do this
+            }
+        }
+        
+        
+       });
+}
+
+
+
+function onLoad(){
+    previous_settings();
+    printAllPages();
+}
+
+
+
+function clearStorage() {
+   
+}
+
+
+// events
+document.getElementById('save').addEventListener('click', save_options);
+document.addEventListener('DOMContentLoaded', onLoad);

--- a/settings.js
+++ b/settings.js
@@ -19,8 +19,9 @@ function previous_settings() {
 function removeSinglePage(e){
     console.warn(`removing ${e.target.id}`)
     chrome.storage.local.set({[`${e.target.id}`]: []}, function() {
-       
+        let removed = document.getElementById(`dynamic-${e.target.id}`).remove();
       });
+      
 
     }
 
@@ -33,7 +34,7 @@ function printAllPages(){ // get all the pages we have settings for from storage
             //console.log(result[page])
             if(result[page].length !== 0){
                 let newItem = document.createElement('div');
-                newItem.innerHTML = `<span style='padding: 5px;background-color:grey;'>${page.replace('ekill-replace-', '')} --- <button id="${page}">Remove</button></span>`;
+                newItem.innerHTML = `<span id='dynamic-${page}' style='padding: 5px;background-color:grey;'>${page.replace('ekill-replace-', '')} --- <button id="${page}">Remove</button></span>`;
                 URLBOX.appendChild(newItem);
                 document.getElementById(page).addEventListener('click', removeSinglePage); // after we add the item we do this
             }


### PR DESCRIPTION
uses a combination of sync(for ekill settings) and storage.local (for removed elemts).

things to keep in mind
1. if you have the option to remember removed elements turned on and try to remove something on youtube.. the second time you visit youtube will crash.. this does not happen with the feature turned off.. youtube is also the only site this seems to happen on
2. if you try and remove a dynamic element that has properties that change on each page visit, it will not remove it the other times the user visits the page (this is due to the script replacing the exact match of the to remove html element) .. working on a fix
3. this new feature is disabled by default. right click and go to the new options page to enable it and then click save