### PR TITLE
Grudge - error elements not getting removed

### DIFF
--- a/ekill.js
+++ b/ekill.js
@@ -125,6 +125,8 @@
 
       if (settings.keepRemoved === "true") {
         saveRemovedElement(e.target, () => e.target.remove());
+      }else{
+        e.target.remove();
       }
       e.preventDefault();
       e.stopPropagation();


### PR DESCRIPTION
## really small typo in here causing elements to not get removed from the page if the grudge feature is on

## see this gif

![ezgif com-optimize](https://user-images.githubusercontent.com/30909481/46981283-b7679400-d0a5-11e8-931a-ce7376531cdf.gif)
